### PR TITLE
Fix terminal width gives 0 under `docker run -ti`

### DIFF
--- a/width.go
+++ b/width.go
@@ -18,6 +18,10 @@ func initWidth() error {
 			return fmt.Errorf("get terminal size failed: %s", err)
 		}
 
+		if w == 0 {
+			w = DefaultWidth
+		}
+
 		SetWidth(w)
 	}
 


### PR DESCRIPTION
Force default term width = 140 if zero width has been detected.