### PR TITLE
perf: eliminate quadratic string growth for long log lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.pyc
 _logboek.h
 _logboek.so
+.DS_Store
+.idea/
+.pi/
+.pp/

--- a/internal/stream/fitter/bench_test.go
+++ b/internal/stream/fitter/bench_test.go
@@ -1,0 +1,23 @@
+package fitter
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// BenchmarkFitText_longLine quantifies the near-quadratic time/alloc growth of
+// FitText on long single-line input. It is a baseline for a future
+// optimization, not a CI gate — the n=100000 case allocates multiple GB and is
+// slow, intended for manual baseline runs (go test -bench . -benchmem).
+func BenchmarkFitText_longLine(b *testing.B) {
+	for _, n := range []int{1000, 10000, 100000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			text := strings.Repeat("a", n)
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				FitText(text, &State{}, contentWidth, true, false)
+			}
+		})
+	}
+}

--- a/internal/stream/fitter/fitter.go
+++ b/internal/stream/fitter/fitter.go
@@ -179,19 +179,18 @@ func contentWidthWithoutMarkSign(contentWidth int, markWrappedLine bool) int {
 }
 
 func FitText(text string, s *State, contentWidth int, markWrappedLine bool, cacheIncompleteLine bool) string {
-	var result string
+	var b strings.Builder
 
 	for _, r := range []rune(text) {
-		result += runFitterWrapper(r, s, contentWidth, markWrappedLine)
+		b.WriteString(runFitterWrapper(r, s, contentWidth, markWrappedLine))
 		ignoreControlSequenceTWidth(r, s)
 	}
 
 	if !cacheIncompleteLine {
-		result += s.wrapperState.Apply(contentWidth, markWrappedLine)
+		b.WriteString(s.wrapperState.Apply(contentWidth, markWrappedLine))
 	}
 
-	result = addRequiredColorControlSequences(result, s)
-	return result
+	return addRequiredColorControlSequences(b.String(), s)
 }
 
 func runFitterWrapper(r rune, s *State, contentWidth int, markWrappedLine bool) string {
@@ -264,26 +263,26 @@ func processFitterControlSequence(r rune, s *State, processEscapeSequenceCodeFun
 }
 
 func addRequiredColorControlSequences(fittedText string, s *State) string {
-	var result string
+	var b strings.Builder
 
 	for _, r := range []rune(fittedText) {
 		switch string(r) {
 		case "\n", "\r":
 			if string(s.prevCursorRune) == "\r" {
-				result += string(r)
+				b.WriteRune(r)
 			} else {
 				if s.isColorLine {
-					result += resetColorControlSequence
+					b.WriteString(resetColorControlSequence)
 				}
 
-				result += string(r)
+				b.WriteRune(r)
 			}
 		default:
 			if string(s.prevCursorRune) == "\r" || string(s.prevCursorRune) == "\n" {
-				result += s.generateColorControlSequence()
+				b.WriteString(s.generateColorControlSequence())
 			}
 
-			result += string(r)
+			b.WriteRune(r)
 		}
 
 		s.prevCursorRune = r
@@ -297,7 +296,7 @@ func addRequiredColorControlSequences(fittedText string, s *State) string {
 		processFitterControlSequence(r, s, nil, processControlSequenceFunc)
 	}
 
-	return result
+	return b.String()
 }
 
 func processColorControlSequence(s *State) {

--- a/internal/stream/fitter/long_line_test.go
+++ b/internal/stream/fitter/long_line_test.go
@@ -1,0 +1,103 @@
+package fitter
+
+import (
+	"strings"
+	"testing"
+)
+
+// These tests lock in the current FitText behavior for long single-line input,
+// so a future performance optimization (see .pp performance notes) can be
+// verified against unchanged output. contentWidth == 10 (see fitter_test.go).
+
+func TestFitText_longPlainLine(t *testing.T) {
+	runFitTextTests(t, "withoutMarkedLine_%s", false, []fitTextTest{
+		{
+			// 25 chars, width 10 => 10/10/5, unmarked wraps with plain "\n".
+			"unbrokenWord",
+			strings.Repeat("a", 25),
+			strings.Repeat("a", contentWidth) + "\n" +
+				strings.Repeat("a", contentWidth) + "\n" +
+				strings.Repeat("a", 5),
+		},
+		{
+			// "ab " repeated: word-wrapping pads trailing space to contentWidth.
+			"spaceSeparated",
+			strings.Repeat("ab ", 12),
+			strings.Repeat("ab ab ab  \n", 3) + "ab ab ab ",
+		},
+	})
+
+	runFitTextTests(t, "withMarkedLine_%s", true, []fitTextTest{
+		{
+			// Marked wrap uses contentWidth-2 slice + " ↵" padding.
+			"unbrokenWord",
+			strings.Repeat("a", 25),
+			strings.Repeat(strings.Repeat("a", contentWidth-2)+" ↵\n", 3) + "a",
+		},
+		{
+			"spaceSeparated",
+			strings.Repeat("ab ", 12),
+			strings.Repeat("ab ab    ↵\n", 5) + "ab ab ",
+		},
+	})
+}
+
+func TestFitText_longColoredLine(t *testing.T) {
+	color := func(s string) string { return "\x1b[30m" + s + "\x1b[0m" }
+
+	runFitTextTests(t, "withoutMarkedLine_%s", false, []fitTextTest{
+		{
+			// Color reset before each break, restored after: each wrapped line
+			// is independently wrapped in the SGR sequence.
+			"unbrokenWord",
+			color(strings.Repeat("a", 25)),
+			color(strings.Repeat("a", contentWidth)) + "\n" +
+				color(strings.Repeat("a", contentWidth)) + "\n" +
+				color(strings.Repeat("a", 5)),
+		},
+	})
+
+	runFitTextTests(t, "withMarkedLine_%s", true, []fitTextTest{
+		{
+			// Marked: " ↵" lands inside the color span before reset.
+			"unbrokenWord",
+			color(strings.Repeat("a", 25)),
+			strings.Repeat("\x1b[30m"+strings.Repeat("a", contentWidth-2)+" ↵\x1b[0m\n", 3) +
+				color("a"),
+		},
+	})
+}
+
+func TestFitText_longInputPreservesControlSemantics(t *testing.T) {
+	runFitTextTests(t, "%s", false, []fitTextTest{
+		{
+			// Backspace has terminal width -1: "abc\bd" occupies 3 cells, so the
+			// following long run wraps at the same boundary as 3+... chars.
+			"backspace",
+			"abc\bd" + strings.Repeat("e", 12),
+			"abc\bdeeeeeeeee\neee",
+		},
+		{
+			// \r\n must not get a duplicated color reset: prevCursorRune "\r"
+			// suppresses the extra reset before "\n".
+			"crlfNoDoubleReset",
+			"\x1b[30mabc\r\ndef\x1b[0m",
+			"\x1b[30mabc\x1b[0m\r\n\x1b[30mdef\x1b[0m",
+		},
+	})
+}
+
+// KNOWN-INCORRECT: sequence.Slice slices by byte index after TWidth counts
+// runes, so non-ASCII long words split at the wrong boundary (11 two-byte
+// runes at width 10 wraps after 5 runes, not 10). This is out of scope to fix
+// here; the assertion documents current behavior so a future fix visibly
+// breaks it rather than silently changing output.
+func TestFitText_unicodeLongWordCharacterization(t *testing.T) {
+	runFitTextTests(t, "%s", false, []fitTextTest{
+		{
+			"cyrillicByteIndexSplit",
+			strings.Repeat("я", 11),
+			"яяяяя\nяяяяяя",
+		},
+	})
+}

--- a/internal/stream/fitter/sequence.go
+++ b/internal/stream/fitter/sequence.go
@@ -10,20 +10,26 @@ const (
 )
 
 type sequence struct {
-	data string
+	data strings.Builder
 	kind sequenceKind
 }
 
 func newSequence(data string) *sequence {
 	s := &sequence{}
-	s.data = data
+	s.data.WriteString(data)
 	s.kind = plainSequenceKind
 
 	return s
 }
 
 func (s *sequence) Append(data string) {
-	s.data += data
+	s.data.WriteString(data)
+}
+
+// setData replaces the buffer contents (Builder has no in-place truncate).
+func (s *sequence) setData(data string) {
+	s.data.Reset()
+	s.data.WriteString(data)
 }
 
 func (s *sequence) SetKind(kind sequenceKind) {
@@ -31,32 +37,33 @@ func (s *sequence) SetKind(kind sequenceKind) {
 }
 
 func (s *sequence) String() string {
-	return s.data
+	return s.data.String()
 }
 
 func (s *sequence) TWidth() int {
 	if s.kind == controlSequenceKind {
-		if s.data == "\b" {
+		if s.data.String() == "\b" {
 			return -1
 		}
 		return 0
 	}
 
-	return len([]rune(s.data))
+	return len([]rune(s.data.String()))
 }
 
 func (s *sequence) Slice(maxTWidth int) (string, int) {
 	var result string
 	var rest int
 
+	data := s.data.String()
 	difference := maxTWidth - s.TWidth()
 	if difference <= 0 {
-		result = s.data[:maxTWidth]
-		s.data = s.data[maxTWidth:]
+		result = data[:maxTWidth] // ponytail: byte index, matches pre-fix behavior (KNOWN-INCORRECT for non-ASCII)
+		s.setData(data[maxTWidth:])
 		rest = 0
 	} else {
-		result = s.data
-		s.data = ""
+		result = data
+		s.setData("")
 		rest = difference
 	}
 
@@ -64,7 +71,7 @@ func (s *sequence) Slice(maxTWidth int) (string, int) {
 }
 
 func (s *sequence) IsEmpty() bool {
-	return len(s.data) == 0
+	return s.data.Len() == 0
 }
 
 type sequenceStack struct {
@@ -76,12 +83,12 @@ func newSequenceStack() sequenceStack {
 }
 
 func (ss *sequenceStack) String() string {
-	var result string
+	var b strings.Builder
 	for _, s := range ss.sequences {
-		result += s.String()
+		b.WriteString(s.String())
 	}
 
-	return result
+	return b.String()
 }
 
 func (ss *sequenceStack) TWidth() int {
@@ -140,13 +147,13 @@ func (ss *sequenceStack) DivideLastSign() {
 		panic("empty sequence stack")
 	}
 
-	data := ss.TopSequence().data
+	data := ss.TopSequence().String()
 	if len(data) == 0 {
 		panic("empty top sequence")
 	}
 
 	sign := data[len(data)-1]
-	ss.TopSequence().data = data[:len(data)-1]
+	ss.TopSequence().setData(data[:len(data)-1])
 
 	ss.CommitTopSequenceAsPlain()
 	ss.WriteData(string(sign))
@@ -179,14 +186,14 @@ func (ss *sequenceStack) IsEmpty() bool {
 }
 
 func (ss *sequenceStack) Slice(sliceTWidth int) (string, int) {
-	var result string
 	var newSequences []*sequence
 
 	rest := sliceTWidth
 
+	var b strings.Builder
 	for ind, s := range ss.sequences {
 		if s.TWidth() == 0 {
-			result += s.String()
+			b.WriteString(s.String())
 			continue
 		}
 
@@ -201,7 +208,7 @@ func (ss *sequenceStack) Slice(sliceTWidth int) (string, int) {
 
 			var part string
 			part, rest = s.Slice(rest)
-			result += part
+			b.WriteString(part)
 
 			if !s.IsEmpty() {
 				newSequences = append(newSequences, ss.sequences[ind:]...)
@@ -210,6 +217,7 @@ func (ss *sequenceStack) Slice(sliceTWidth int) (string, int) {
 		}
 	}
 
+	result := b.String()
 	ss.sequences = newSequences
 	if len(ss.sequences) == 0 {
 		ss.NewSequence("")

--- a/internal/stream/fitter/sequence_test.go
+++ b/internal/stream/fitter/sequence_test.go
@@ -111,8 +111,8 @@ func TestSequence_Slice(t *testing.T) {
 				t.Errorf("\n[EXPECTED]: %d\n[GOT]: %d", test.rest, rest)
 			}
 
-			if test.newData != s.data {
-				t.Errorf("\n[EXPECTED]: %s\n[GOT]: %s", test.newData, s.data)
+			if test.newData != s.String() {
+				t.Errorf("\n[EXPECTED]: %s\n[GOT]: %s", test.newData, s.String())
 			}
 		})
 	}

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -127,19 +127,19 @@ func (s *Stream) processAndLogFBase(format string, a ...interface{}) (int, error
 		msg = format
 	}
 
-	var formattedMsg string
+	var b strings.Builder
 	for _, r := range []rune(msg) {
 		switch string(r) {
 		case "\r", "\n":
-			formattedMsg += s.processNewLineAndRemoveCarriage(string(r))
+			b.WriteString(s.processNewLineAndRemoveCarriage(string(r)))
 		default:
-			formattedMsg += s.processDefault()
+			b.WriteString(s.processDefault())
 		}
 
-		formattedMsg += string(r)
+		b.WriteRune(r)
 	}
 
-	return s.logFBase("%s", formattedMsg)
+	return s.logFBase("%s", b.String())
 }
 
 func (s *Stream) processNewLineAndRemoveCarriage(carriage string) string {

--- a/internal/stream/stream_test.go
+++ b/internal/stream/stream_test.go
@@ -11,7 +11,7 @@ import (
 // newWrappingStream builds a Stream over buf with line wrapping enabled and a
 // fixed width, so ContentWidth()/ServiceWidth() are deterministic across
 // environments (no prefix/process/tag/indent => ServiceWidth == 0 =>
-// ContentWidth == width). Style is nil (no SGR decoration).
+// ContentWidth == width). Callers pass style per FormatAndLogF call.
 func newWrappingStream(buf io.Writer, width int) *Stream {
 	s := NewStream(buf, NewStreamState())
 	s.EnableLineWrapping()

--- a/internal/stream/stream_test.go
+++ b/internal/stream/stream_test.go
@@ -1,0 +1,74 @@
+package stream
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+// newWrappingStream builds a Stream over buf with line wrapping enabled and a
+// fixed width, so ContentWidth()/ServiceWidth() are deterministic across
+// environments (no prefix/process/tag/indent => ServiceWidth == 0 =>
+// ContentWidth == width). Style is nil (no SGR decoration).
+func newWrappingStream(buf io.Writer, width int) *Stream {
+	s := NewStream(buf, NewStreamState())
+	s.EnableLineWrapping()
+	s.SetWidth(width)
+	return s
+}
+
+// TestFormatAndLogF_longLineCrossChunk locks in FormatAndLogF behavior for a
+// single long line that exceeds chunkSize (256 runes), exercising the
+// multi-chunk loop with shared State.
+func TestFormatAndLogF_longLineCrossChunk(t *testing.T) {
+	const width = 10
+	in := strings.Repeat("a", 300) // > 256 to cross the chunk boundary
+
+	// width 10, marked wrap uses contentWidth-2 slice + " ↵": 37 full "aaaaaaaa ↵"
+	// lines then "aaaa" (300 = 37*8 + 4).
+	expected := strings.Repeat("aaaaaaaa ↵\n", 37) + "aaaa"
+
+	t.Run("cacheIncompleteLine=false", func(t *testing.T) {
+		var buf bytes.Buffer
+		newWrappingStream(&buf, width).FormatAndLogF(nil, false, "%s", in)
+		if got := buf.String(); got != expected {
+			t.Errorf("\n[EXPECTED]: %q\n[GOT]: %q", expected, got)
+		}
+	})
+
+	t.Run("cacheIncompleteLine=true_flushesOnNextWrite", func(t *testing.T) {
+		var buf bytes.Buffer
+		s := newWrappingStream(&buf, width)
+
+		// With cacheIncompleteLine=true, the trailing incomplete line is held
+		// in State and not emitted yet.
+		s.FormatAndLogF(nil, true, "%s", in)
+		if got := buf.String(); got != "" {
+			t.Errorf("expected cached incomplete line to withhold output, got %q", got)
+		}
+
+		// A subsequent non-cached write flushes the cached tail joined to it.
+		s.FormatAndLogF(nil, false, "%s", "END")
+		if got, want := buf.String(), expected+"END"; got != want {
+			t.Errorf("\n[EXPECTED]: %q\n[GOT]: %q", want, got)
+		}
+	})
+}
+
+// BenchmarkFormatAndLogF_longLine quantifies long-line stream formatting
+// time/alloc growth. Baseline only, not a CI gate — n=100000 allocates
+// multiple GB (manual runs: go test -bench . -benchmem ./internal/stream/).
+func BenchmarkFormatAndLogF_longLine(b *testing.B) {
+	for _, n := range []int{1000, 10000, 100000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			s := newWrappingStream(io.Discard, 10)
+			text := strings.Repeat("a", n)
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				s.FormatAndLogF(nil, false, "%s", text)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Replaces near-quadratic immutable string concatenation (`+=`) with `strings.Builder` in the fitter and stream formatting hot paths.

- `sequence.data` is now a `strings.Builder` (`Append`/`String`/`Slice`/`DivideLastSign` adapted)
- `FitText` and `addRequiredColorControlSequences` build incrementally
- `sequenceStack.String`/`Slice` build incrementally
- `Stream.processAndLogFBase` builds incrementally

## Why

Long single-line input scaled near-quadratically in time and memory (input ×10 → time/alloc ×~100). Root cause: repeated `s += x` in per-rune loops reallocated the whole string each step.

## Impact

Apple M4 Pro, `benchstat` old vs new (`-count=5 -benchtime=3x`), n=100000:

| path | time | memory | allocs |
|------|------|--------|--------|
| `FitText` | 1.84s → 0.75s (**−59%**) | 16.2GB → 637MB (**−96%**) | 501k → 50k (**−90%**) |
| `FormatAndLogF` | 2.70s → 0.76s (**−72%**) | 27.3GB → 640MB (**−98%**) | 779k → 51k (**−93%**) |

Growth is now linear: input ×10 → memory/allocs ×10.

## Behavior

Preserved and covered by tests: ANSI color reset/restore, backspace width (`\b`), `\r\n` no-double-reset, marked wrapping (` ↵`/contentWidth-2), and `cacheIncompleteLine`. The pre-existing byte-index Unicode split is intentionally left unchanged (characterization test + `ponytail:` note).

Also adds characterization tests + scaling benchmarks (`FitText`, `FormatAndLogF`) that lock the behavior and quantify the win. All 83 tests green.