### PR TITLE
test: cover Context/MustContext fallback and panic paths

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,53 @@
+package logboek
+
+import (
+	"os"
+	"testing"
+
+	"golang.org/x/net/context"
+)
+
+func TestContextFallsBackToDefaultLogger(t *testing.T) {
+	cases := map[string]context.Context{
+		"nil context":            nil,
+		"background context":     context.Background(),
+		"context without logger": context.WithValue(context.Background(), "unrelated", "x"),
+	}
+	for name, ctx := range cases {
+		if got := Context(ctx); got != DefaultLogger() {
+			t.Errorf("%s: Context() = %v, want DefaultLogger()", name, got)
+		}
+	}
+}
+
+func TestContextReturnsBoundLogger(t *testing.T) {
+	l := NewLogger(os.Stdout, os.Stderr)
+	ctx := NewContext(context.Background(), l)
+	if got := Context(ctx); got != l {
+		t.Errorf("Context() = %v, want bound logger %v", got, l)
+	}
+}
+
+func TestMustContextPanicsWithoutLogger(t *testing.T) {
+	for name, ctx := range map[string]context.Context{
+		"nil context":        nil,
+		"background context": context.Background(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Error("MustContext() did not panic")
+				}
+			}()
+			MustContext(ctx)
+		})
+	}
+}
+
+func TestMustContextReturnsBoundLogger(t *testing.T) {
+	l := NewLogger(os.Stdout, os.Stderr)
+	ctx := NewContext(context.Background(), l)
+	if got := MustContext(ctx); got != l {
+		t.Errorf("MustContext() = %v, want bound logger %v", got, l)
+	}
+}


### PR DESCRIPTION
Follow-up to #76.

Adds regression tests for the panic-free `Context(ctx)` and strict `MustContext(ctx)` behaviour introduced in #76:

- `Context(nil)` / `context.Background()` / context without logger → returns `DefaultLogger()` (no panic)
- `Context(NewContext(bg, l))` → returns the bound logger
- `MustContext(nil)` / `context.Background()` → panics
- `MustContext(NewContext(bg, l))` → returns the bound logger

No framework, plain `testing`. Closes the tests task in #75.