### PR TITLE
fix: cut multibyte runs on rune boundary in sequence.Slice

### DIFF
--- a/internal/stream/fitter/long_line_test.go
+++ b/internal/stream/fitter/long_line_test.go
@@ -87,17 +87,20 @@ func TestFitText_longInputPreservesControlSemantics(t *testing.T) {
 	})
 }
 
-// KNOWN-INCORRECT: sequence.Slice slices by byte index after TWidth counts
-// runes, so non-ASCII long words split at the wrong boundary (11 two-byte
-// runes at width 10 wraps after 5 runes, not 10). This is out of scope to fix
-// here; the assertion documents current behavior so a future fix visibly
-// breaks it rather than silently changing output.
-func TestFitText_unicodeLongWordCharacterization(t *testing.T) {
+// sequence.Slice cuts on rune boundaries: 11 two-byte runes at width 10 wrap
+// after 10 runes, and multibyte glyphs (emoji, CJK, Cyrillic) never split
+// mid-byte into replacement chars.
+func TestFitText_unicodeLongWord(t *testing.T) {
 	runFitTextTests(t, "%s", false, []fitTextTest{
 		{
-			"cyrillicByteIndexSplit",
+			"cyrillicRuneBoundarySplit",
 			strings.Repeat("я", 11),
-			"яяяяя\nяяяяяя",
+			"яяяяяяяяяя\nя",
+		},
+		{
+			"emojiNotSplitMidByte",
+			strings.Repeat("🛳", 11),
+			"🛳🛳🛳🛳🛳🛳🛳🛳🛳🛳\n🛳",
 		},
 	})
 }

--- a/internal/stream/fitter/sequence.go
+++ b/internal/stream/fitter/sequence.go
@@ -93,21 +93,24 @@ func (s *sequence) Slice(maxTWidth int) (string, int) {
 	content := s.content()
 	difference := maxTWidth - s.TWidth()
 	if difference <= 0 {
-		// ponytail: byte index, matches pre-fix behavior (KNOWN-INCORRECT for non-ASCII)
-		result := content[:maxTWidth]
 		isASCII := s.twidth == len(content) // byte==rune => pure ASCII view
-		s.off += maxTWidth
 		if isASCII {
-			// ASCII fast-path: byte==rune so this is exact and O(1); the tail
-			// of an ASCII string is ASCII, so the cache stays valid across cuts
-			// and countrunes leaves the hot loop.
+			// ASCII fast-path: byte==rune so cutting at maxTWidth is exact and O(1);
+			// the tail of an ASCII string is ASCII, so the cache stays valid.
+			result := content[:maxTWidth]
+			s.off += maxTWidth
 			s.twidth -= maxTWidth
-		} else {
-			// multibyte: recount exactly next TWidth() (bit-for-bit old behavior,
-			// incl. mid-rune orphan-fragment counting).
-			s.twValid = false
+			return result, 0
 		}
-		return result, 0
+		// multibyte: cut on a rune boundary so emoji/wide chars never split mid-byte.
+		byteLen := 0
+		for i := 0; i < maxTWidth; i++ {
+			_, size := utf8.DecodeRuneInString(content[byteLen:])
+			byteLen += size
+		}
+		s.off += byteLen
+		s.twValid = false
+		return content[:byteLen], 0
 	}
 
 	s.off = len(s.str)

--- a/internal/stream/fitter/sequence_test.go
+++ b/internal/stream/fitter/sequence_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestSequence_NewSequence(t *testing.T) {
@@ -325,6 +326,42 @@ func TestSequenceStack_Slice(t *testing.T) {
 					}
 				}
 
+			}
+		})
+	}
+}
+
+// TestSequence_Slice_multibyteRuneBoundary pins the reported corruption bug.
+// maxTWidth is a rune count; the buggy Slice cut content[:maxTWidth] by BYTE,
+// splitting a multibyte glyph mid-sequence and yielding invalid UTF-8 that
+// terminals render as U+FFFD (�). Against the unfixed code this fails on
+// both the invalid-UTF-8 check and the rune-count check.
+func TestSequence_Slice_multibyteRuneBoundary(t *testing.T) {
+	const maxTWidth = 3
+	tests := []struct{ name, data string }{
+		{"cyrillic", strings.Repeat("я", 6)},   // 2 bytes/rune
+		{"emojiShip", strings.Repeat("🛳", 6)}, // 4 bytes/rune
+		{"cjk", strings.Repeat("漢", 6)},        // 3 bytes/rune
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := newSequence(test.data)
+			s.SetKind(plainSequenceKind)
+
+			head, rest := s.Slice(maxTWidth)
+
+			if rest != 0 {
+				t.Fatalf("rest: expected 0, got %d", rest)
+			}
+			if !utf8.ValidString(head) {
+				t.Errorf("sliced head is not valid UTF-8 (mid-rune cut): %q", head)
+			}
+			if !utf8.ValidString(s.String()) {
+				t.Errorf("sliced tail is not valid UTF-8 (mid-rune cut): %q", s.String())
+			}
+			if n := utf8.RuneCountInString(head); n != maxTWidth {
+				t.Errorf("head rune count: expected %d, got %d (%q)", maxTWidth, n, head)
 			}
 		})
 	}


### PR DESCRIPTION
## What

Fixes UTF-8 corruption when wrapping long multibyte lines. `(*sequence).Slice` cut long-run content at a **byte** index (`content[:maxTWidth]`) while `maxTWidth` is a **rune** count — slicing inside a multibyte UTF-8 sequence and emitting invalid bytes that terminals render as `�` (U+FFFD).

Reported symptom (emoji prefix in wrapped log output):

```
│ ��� Building stage a/from
```

PR #79 explicitly deferred this as a "KNOWN-INCORRECT" split; this fixes it.

## How

- Multibyte branch of `Slice` now walks `maxTWidth` runes via `utf8.DecodeRuneInString` and cuts on the rune boundary.
- ASCII fast-path (byte==rune) unchanged and O(1) — the linear-wrap perf of PR #79 is preserved.
- No new dependency (`unicode/utf8` already imported); no `go.mod`/`go.sum` change.

## Tests

- `TestSequence_Slice_multibyteRuneBoundary` (new) — **fails on the pre-fix code** (`"я\xd1"` mid-rune cut, invalid UTF-8, wrong rune count), passes with the fix. Covers Cyrillic / emoji / CJK.
- `TestFitText_unicodeLongWord` — replaces the old characterization test that locked in the broken split; asserts correct rune-boundary wrap + emoji regression guard (`"🛳"×11` → 10-then-1, no `�`).
- `go build ./...`, `go vet ./internal/stream/fitter/`, `go test ./...` all green (94 tests).

## Out of scope (follow-up)

`TWidth` counts runes, not terminal display cells — wide glyphs (CJK, `🛳️` = ship + VS16) still mis-align columns, and grapheme clusters (ZWJ/flags/skin-tone) can split at a wrap without producing `�`. Correct alignment needs an east-asian-width/grapheme-width table; intentionally not pulling a new dependency here.
